### PR TITLE
move rotation logic to the composite node.

### DIFF
--- a/src/AVL-Tree/AVLAbstractNode.class.st
+++ b/src/AVL-Tree/AVLAbstractNode.class.st
@@ -7,6 +7,16 @@ Class {
 	#category : #'AVL-Tree'
 }
 
+{ #category : #adding }
+AVLAbstractNode >> addChild: newObject [
+	^ self subclassResponsibility
+]
+
+{ #category : #private }
+AVLAbstractNode >> checkRemovingPath: path [
+	self subclassResponsibility
+]
+
 { #category : #accessing }
 AVLAbstractNode >> children [
 	^ {  }

--- a/src/AVL-Tree/AVLNilNode.class.st
+++ b/src/AVL-Tree/AVLNilNode.class.st
@@ -7,6 +7,15 @@ Class {
 	#category : #'AVL-Tree'
 }
 
+{ #category : #adding }
+AVLNilNode >> addChild: newObject [
+	^ AVLNode with: newObject
+]
+
+{ #category : #private }
+AVLNilNode >> checkRemovingPath: path [
+]
+
 { #category : #testing }
 AVLNilNode >> isNilNode [
 	^ true

--- a/src/AVL-Tree/AVLNode.class.st
+++ b/src/AVL-Tree/AVLNode.class.st
@@ -40,6 +40,75 @@ AVLNode >> add: anInteger path: list [
 	
 ]
 
+{ #category : #adding }
+AVLNode >> addChild: newObject [
+	| path |
+	path := OrderedCollection with: nil -> self.
+	self add: newObject path: path.
+	self checkPath: path.
+	^ self
+]
+
+{ #category : #private }
+AVLNode >> balance: index path: aCollection [ 
+	| x y z a b c |
+	z := aCollection at: index.
+	y := aCollection at: index + 1.
+	x := aCollection at: index + 2.
+	c := z value.
+	b := y value.
+	a := x value.
+	(y key and: [ x key ]) ifTrue: [ 
+		^ self rrrotationZ: c y: b x: a ].
+	(y key not and: [ x key not ]) ifTrue: [ 
+		^ self llrotationZ: c y: b x: a ].
+	(y key not and: [ x key ]) ifTrue: [ 
+		^ self lrrotationZ: c y: b x: a ].
+	"(y key and: [ x key not ])"
+	^ self rlrotationZ: c y: b x: a.
+	"self notYetImplemented."
+]
+
+{ #category : #private }
+AVLNode >> balanceZ: z y: y x: x [
+	| a b c |
+	c := z value.
+	b := y value.
+	a := x value.
+	(y key and: [ x key ]) ifTrue: [ 
+		^ self rrrotationZ: c y: b x: a ].
+	(y key not and: [ x key not ]) ifTrue: [ 
+		^ self llrotationZ: c y: b x: a ].
+	(y key not and: [ x key ]) ifTrue: [ 
+		^ self lrrotationZ: c y: b x: a ].
+	"(y key and: [ x key not ])"
+	^ self rlrotationZ: c y: b x: a.
+	"self notYetImplemented."
+]
+
+{ #category : #private }
+AVLNode >> checkPath: aCollection [ 
+	aCollection size < 3 ifTrue: [ ^ self ].
+	(1 to: aCollection size - 2) reverseDo: [ :index |
+		| assoc |
+		assoc := aCollection at: index.
+		assoc value isBalanced ifFalse: [ | z y x |
+			z := aCollection at: index.
+			y := aCollection at: index + 1.
+			x := aCollection at: index + 2.
+			^ self balanceZ: z y: y x: x ] ]
+]
+
+{ #category : #private }
+AVLNode >> checkRemovingPath: path [
+	path reverseDo: [ :node | 
+		node isBalanced ifFalse: [ | z y x |
+			z := node.
+			y := z largerNode.
+			x := y value largerNode.
+			self balanceZ: node y: y x: x ] ].
+]
+
 { #category : #accessing }
 AVLNode >> children [
 	^ { left. right } reject: #isNil
@@ -119,6 +188,31 @@ AVLNode >> left: aNode [
 	left := aNode
 ]
 
+{ #category : #private }
+AVLNode >> llrotationZ: z y: y x: x [ 
+	| a3 a4 new |
+	a3 := y right.
+	a4 := z right.
+	
+	new := self class with: z contents.
+	new left: a3; right: a4.
+	z left: x; contents: y contents; right: new.
+	
+]
+
+{ #category : #private }
+AVLNode >> lrrotationZ: z y: y x: x [ 
+	| a1 a2 a3 new |
+	a1 := y left.
+	a2 := x left.
+	a3 := x right.
+	new := self class with: y contents.
+	new left: a1; right: a2.
+	y contents: x contents; left: new; right: a3.
+	
+	self llrotationZ: z y: y x: new
+]
+
 { #category : #printing }
 AVLNode >> printOn: stream [
 	contents printOn: stream
@@ -172,6 +266,32 @@ AVLNode >> right [
 { #category : #accessing }
 AVLNode >> right: anObject [ 
 	right := anObject
+]
+
+{ #category : #private }
+AVLNode >> rlrotationZ: z y: y x: x [ 
+	| a1 a2 a3 a4 new |
+	a1 := z left.
+	a2 := x left.
+	a3 := x right.
+	a4 := y right.
+	new := self class with: y contents.
+	new left: a3; right: a4.
+	y contents: x contents; left: a2; right: new.
+	self rrrotationZ: z y: y x: new
+]
+
+{ #category : #private }
+AVLNode >> rrrotationZ: z y: y x: x [
+	"right right rotation"
+	| a1 a2 new |
+	a1 := z left.
+	a2 := y left.
+	
+	new := self class with: z contents.
+	new left: a1; right: a2.
+	z left: new; right: x; contents: y contents
+	
 ]
 
 { #category : #search }

--- a/src/AVL-Tree/AVLTree.class.st
+++ b/src/AVL-Tree/AVLTree.class.st
@@ -12,12 +12,7 @@ Class {
 
 { #category : #adding }
 AVLTree >> add: newObject [ 
-	root isNilNode
-		ifTrue: [ root := AVLNode with: newObject ]
-		ifFalse: [ | path |
-			path := OrderedCollection with: nil -> root.
-			root add: newObject path: path.
-			self checkPath: path  ].
+	root := root addChild: newObject.
 	^ newObject
 ]
 
@@ -27,66 +22,6 @@ AVLTree >> allChildren [
 	list := OrderedCollection new.
 	self root withAllChildren: list.
 	^ list
-]
-
-{ #category : #private }
-AVLTree >> balance: index path: aCollection [ 
-	| x y z a b c |
-	z := aCollection at: index.
-	y := aCollection at: index + 1.
-	x := aCollection at: index + 2.
-	c := z value.
-	b := y value.
-	a := x value.
-	(y key and: [ x key ]) ifTrue: [ 
-		^ self rrrotationZ: c y: b x: a ].
-	(y key not and: [ x key not ]) ifTrue: [ 
-		^ self llrotationZ: c y: b x: a ].
-	(y key not and: [ x key ]) ifTrue: [ 
-		^ self lrrotationZ: c y: b x: a ].
-	"(y key and: [ x key not ])"
-	^ self rlrotationZ: c y: b x: a.
-	"self notYetImplemented."
-]
-
-{ #category : #private }
-AVLTree >> balanceZ: z y: y x: x [
-	| a b c |
-	c := z value.
-	b := y value.
-	a := x value.
-	(y key and: [ x key ]) ifTrue: [ 
-		^ self rrrotationZ: c y: b x: a ].
-	(y key not and: [ x key not ]) ifTrue: [ 
-		^ self llrotationZ: c y: b x: a ].
-	(y key not and: [ x key ]) ifTrue: [ 
-		^ self lrrotationZ: c y: b x: a ].
-	"(y key and: [ x key not ])"
-	^ self rlrotationZ: c y: b x: a.
-	"self notYetImplemented."
-]
-
-{ #category : #private }
-AVLTree >> checkPath: aCollection [ 
-	aCollection size < 3 ifTrue: [ ^ self ].
-	(1 to: aCollection size - 2) reverseDo: [ :index |
-		| assoc |
-		assoc := aCollection at: index.
-		assoc value isBalanced ifFalse: [ | z y x |
-			z := aCollection at: index.
-			y := aCollection at: index + 1.
-			x := aCollection at: index + 2.
-			^ self balanceZ: z y: y x: x ] ]
-]
-
-{ #category : #private }
-AVLTree >> checkRemovingPath: path [
-	path reverseDo: [ :node | 
-		node isBalanced ifFalse: [ | z y x |
-			z := node.
-			y := z largerNode.
-			x := y value largerNode.
-			self balanceZ: node y: y x: x ] ].
 ]
 
 { #category : #enumerating }
@@ -122,73 +57,25 @@ AVLTree >> isTotalBalanced [
 	^ root isTotalBalanced
 ]
 
-{ #category : #private }
-AVLTree >> llrotationZ: z y: y x: x [ 
-	| a3 a4 new |
-	a3 := y right.
-	a4 := z right.
-	
-	new := AVLNode with: z contents.
-	new left: a3; right: a4.
-	z left: x; contents: y contents; right: new.
-	
-]
-
-{ #category : #private }
-AVLTree >> lrrotationZ: z y: y x: x [ 
-	| a1 a2 a3 new |
-	a1 := y left.
-	a2 := x left.
-	a3 := x right.
-	new := AVLNode with: y contents.
-	new left: a1; right: a2.
-	y contents: x contents; left: new; right: a3.
-	
-	self llrotationZ: z y: y x: new
-]
-
 { #category : #removing }
 AVLTree >> remove: oldObject ifAbsent: anExceptionBlock [
 	| toRemove path |
 	path := OrderedCollection new.
 	toRemove := root remove: oldObject path: path.
 	toRemove ifNil: [ ^ anExceptionBlock value ].
+	
 	toRemove == root ifTrue: [ 
 		root := root successor: path.
 		root ifNil: [ root := AVLNilNode new ] ].
-	self checkRemovingPath: path.
+	root checkRemovingPath: path.
+	
+	
 	^ toRemove contents
-]
-
-{ #category : #private }
-AVLTree >> rlrotationZ: z y: y x: x [ 
-	| a1 a2 a3 a4 new |
-	a1 := z left.
-	a2 := x left.
-	a3 := x right.
-	a4 := y right.
-	new := AVLNode with: y contents.
-	new left: a3; right: a4.
-	y contents: x contents; left: a2; right: new.
-	self rrrotationZ: z y: y x: new
 ]
 
 { #category : #accessing }
 AVLTree >> root [
 	^ root
-]
-
-{ #category : #private }
-AVLTree >> rrrotationZ: z y: y x: x [
-	"right right rotation"
-	| a1 a2 new |
-	a1 := z left.
-	a2 := y left.
-	
-	new := AVLNode with: z contents.
-	new left: a1; right: a2.
-	z left: new; right: x; contents: y contents
-	
 ]
 
 { #category : #search }


### PR DESCRIPTION
This pull requests cleans also the add method in AVLTree
```st
AVLTree >> add: newObject 
	root := root addChild: newObject.
	^ newObject
```