### PR TITLE
modification test isLeaf for killing mutants

### DIFF
--- a/src/AVL-Tree-Tests/AVLTreeTest.class.st
+++ b/src/AVL-Tree-Tests/AVLTreeTest.class.st
@@ -109,7 +109,15 @@ AVLTreeTest >> testIsLeaf [
 
 	self assert: tree root isNilNode.
 	tree add: 1.
-	self assert: tree root isLeaf
+	self assert: tree root isLeaf.
+	
+	tree add: 10.
+	self deny: tree root isLeaf.
+	
+	tree:= AVLTree new.
+	tree add: 10.
+	tree add: 5.
+	self deny: tree root isLeaf.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Hello !

When i try mutationTesting on the AVL project. I got 3 mutants for the message IsLeaf of the class Node who survive.
So i modify the test IsLeaf to kill them.

The test doesn't verify when the root has a child. So i add a Node to the left of the root and then to the right.