### PR TITLE
remove the sender root of the class AVLTree to to avoid misuse.

### DIFF
--- a/src/AVL-Tree-Tests/AVLTreeTest.class.st
+++ b/src/AVL-Tree-Tests/AVLTreeTest.class.st
@@ -107,17 +107,17 @@ AVLTreeTest >> testIsBalanced [
 { #category : #tests }
 AVLTreeTest >> testIsLeaf [
 
-	self assert: tree root isNilNode.
+	self assert: tree isNil.
 	tree add: 1.
-	self assert: tree root isLeaf.
+	self assert: tree isLeaf.
 	
 	tree add: 10.
-	self deny: tree root isLeaf.
+	self deny: tree isLeaf.
 	
 	tree:= AVLTree new.
 	tree add: 10.
 	tree add: 5.
-	self deny: tree root isLeaf.
+	self deny: tree isLeaf.
 ]
 
 { #category : #tests }

--- a/src/AVL-Tree/AVLTree.class.st
+++ b/src/AVL-Tree/AVLTree.class.st
@@ -20,7 +20,7 @@ AVLTree >> add: newObject [
 AVLTree >> allChildren [
 	| list |
 	list := OrderedCollection new.
-	self root withAllChildren: list.
+	root withAllChildren: list.
 	^ list
 ]
 
@@ -51,6 +51,18 @@ AVLTree >> isBalanced [
 	^ root isBalanced
 ]
 
+{ #category : #search }
+AVLTree >> isLeaf [ 
+
+	^ root isLeaf 
+]
+
+{ #category : #search }
+AVLTree >> isNil [ 
+
+	^ root isNilNode  
+]
+
 { #category : #testing }
 AVLTree >> isTotalBalanced [
 
@@ -71,11 +83,6 @@ AVLTree >> remove: oldObject ifAbsent: anExceptionBlock [
 	
 	
 	^ toRemove contents
-]
-
-{ #category : #accessing }
-AVLTree >> root [
-	^ root
 ]
 
 { #category : #search }


### PR DESCRIPTION
Hello !
Before there are 2 ways to add a value on a AVLTree we can do : 
```smallTalk
tree := AVLTree new.
tree add: 10.
tree add:5.
tree add:15
```
and we get this 
![image](https://github.com/pharo-containers/AVL/assets/124277643/55471293-f1b8-4869-b176-c28610e55380)
It works well.

<strong> but </Strong>

We can also do this:
```smallTalk
tree := AVLTree new.
tree add:10.
tree root left: (AVLNode new contents:5).
tree root right: (AVLNode new contents:15).
```
We obtain the same result. 

There is one problem with the second way. We can do something like that:
```SmallTalk
tree := AVLTree new.
tree add:10.
tree root left: (AVLNode new contents:20).
tree root right: (AVLNode new contents:2).
tree root right right: (AVLNode new contents:13).
tree root right right left: (AVLNode new contents:11
```
We obtain this :
![image](https://github.com/pharo-containers/AVL/assets/124277643/b2445b07-650b-4c82-a1e5-d6949536f014)

It is only by looking at the visualization that we see a problem.
Furthemore the value 20 is on left side to the root but the root is 10, it's also a problem.

<strong> To avoid this problem </Strong> I delete the sender root and use the instanceVariable root when it's necessary.
The user is obliged to use the message ```add:``` of the class tree

