### PR TITLE
Add testRemoveFromEmptyTree to verify removal from empty AVL tree

### DIFF
--- a/src/AVL-Tree-Tests/AVLTreeTest.class.st
+++ b/src/AVL-Tree-Tests/AVLTreeTest.class.st
@@ -329,3 +329,12 @@ AVLTreeTest >> testSizeAfterRemoval [
 	tree remove: 3.
 	self assert: tree size equals: 4
 ]
+
+{ #category : #tests }
+AVLTreeTest >> testRemoveFromEmptyTree [
+    | executed |
+    executed := false.
+    tree remove: 42 ifAbsent: [ executed := true ].
+    self assert: executed description: 'The ifAbsent: block should execute when removing from an empty tree'.
+    self assert: tree isEmpty description: 'Tree should remain empty after removal attempt'.
+]


### PR DESCRIPTION
This PR addresses #16 by adding a new test case, `testRemoveFromEmptyTree`, to `AVLTreeTest` in the `AVL-Tree-Tests` package. The test verifies that attempting to remove an element from an empty `AVLTree` correctly triggers the `ifAbsent:` block and leaves the tree unchanged, improving test coverage for edge cases in the `remove:ifAbsent:` method.

### Changes
- **File Modified**: `src/AVL-Tree-Tests/AVLTreeTest.class.st`
  - Added a new method `testRemoveFromEmptyTree` under the `#tests` category.
- **Test Details**:
  - Creates a flag `executed` to track if the `ifAbsent:` block runs.
  - Attempts to remove an arbitrary value (42) from an empty tree.
  - Asserts that the block executes and the tree remains empty.
- **Code**:
```
{ #category : #tests }
AVLTreeTest >> testRemoveFromEmptyTree [
    | executed |
    executed := false.
    tree remove: 42 ifAbsent: [ executed := true ].
    self assert: executed description: 'The ifAbsent: block should execute when removing from an empty tree'.
    self assert: tree isEmpty description: 'Tree should remain empty after removal attempt'.
]
```