### PR TITLE
Make AVLTree >> remove:ifAbsent: block optional with default nil return

### DIFF
--- a/src/AVL-Tree/AVLTree.class.st
+++ b/src/AVL-Tree/AVLTree.class.st
@@ -95,18 +95,18 @@ AVLTree >> isTotalBalanced [
 
 { #category : 'removing' }
 AVLTree >> remove: oldObject ifAbsent: anExceptionBlock [
-	| toRemove path |
-	path := OrderedCollection new.
-	toRemove := root remove: oldObject path: path.
-	toRemove ifNil: [ ^ anExceptionBlock value ].
-	
-	toRemove == root ifTrue: [ 
-		root := root successor: path.
-		root ifNil: [ root := AVLNilNode new ] ].
-	root checkRemovingPath: path.
-	
-	
-	^ toRemove contents
+    | toRemove path defaultBlock |
+    path := OrderedCollection new.
+    defaultBlock := anExceptionBlock ifNil: [ [ nil ] ].
+    toRemove := root remove: oldObject path: path.
+    toRemove ifNil: [ ^ defaultBlock value ].
+    
+    toRemove == root ifTrue: [ 
+        root := root successor: path.
+        root ifNil: [ root := AVLNilNode new ] ].
+    root checkRemovingPath: path.
+    
+    ^ toRemove contents
 ]
 
 { #category : 'search' }


### PR DESCRIPTION
### Behavior (Before)
- If the oldObject was found, the method removed it and returned its contents.
- If the oldObject was not found, it evaluated the anExceptionBlock and returned its result.
- If no ifAbsent: block was provided (e.g., tree remove: 50 ifAbsent: nil), the method would raise an error because anExceptionBlock value would attempt to send value to nil.

### Code (After)
The updated AVLTree >> remove:ifAbsent: method now handles the case where the ifAbsent: block is not provided, defaulting to returning nil: