### PR TITLE
Refactor: Extract node tests into dedicated CTAVLNodeTest class

### DIFF
--- a/src/Containers-AVL-Tree-Tests/CTAVLNodeTest.class.st
+++ b/src/Containers-AVL-Tree-Tests/CTAVLNodeTest.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'CTAVLNodeTest',
+	#superclass : 'TestCase',
+	#category : 'Containers-AVL-Tree-Tests',
+	#package : 'Containers-AVL-Tree-Tests'
+}
+
+{ #category : 'tests' }
+CTAVLNodeTest >> testCopyLeafNode [
+	| node copiedNode |
+	node := CTAVLNode new contents: 42.
+	
+	copiedNode := node copy.
+	
+	self assert: copiedNode contents equals: 42.
+	self deny: node == copiedNode.
+	
+	self assert: copiedNode height equals: 1.
+	self assert: copiedNode left isNilNode.
+	self assert: copiedNode right isNilNode
+]
+
+{ #category : 'tests' }
+CTAVLNodeTest >> testIsLeaf [
+    | parentNode childNode |
+    parentNode := CTAVLNode new contents: 50.
+    self assert: parentNode isLeaf.
+
+    childNode := CTAVLNode new contents: 30.
+    parentNode left: childNode.
+
+    self deny: parentNode isLeaf.
+    self assert: childNode isLeaf.
+]
+
+{ #category : 'tests' }
+CTAVLNodeTest >> testParentChildRelationships [
+    | root leftChild rightChild |
+    root := CTAVLNode new contents: 50.
+    leftChild := CTAVLNode new contents: 30.
+    rightChild := CTAVLNode new contents: 70.
+
+    root left: leftChild.
+    root right: rightChild.
+
+    self assert: root parent isNil.
+    self assert: leftChild parent equals: root.
+    self assert: rightChild parent equals: root.
+]

--- a/src/Containers-AVL-Tree-Tests/CTAVLTreeTest.class.st
+++ b/src/Containers-AVL-Tree-Tests/CTAVLTreeTest.class.st
@@ -149,21 +149,6 @@ CTAVLTreeTest >> testCopyLargeTree [
 ]
 
 { #category : 'tests' }
-CTAVLTreeTest >> testCopyLeafNode [
-	| node copiedNode |
-	node := CTAVLNode new contents: 42.
-	
-	copiedNode := node copy.
-	
-	self assert: copiedNode contents equals: 42.
-	self deny: node == copiedNode.
-	
-	self assert: copiedNode height equals: 1.
-	self assert: copiedNode left isNilNode.
-	self assert: copiedNode right isNilNode
-]
-
-{ #category : 'tests' }
 CTAVLTreeTest >> testCopySingleNode [
 	| copiedTree |
 	
@@ -374,17 +359,6 @@ CTAVLTreeTest >> testIncludes [
 ]
 
 { #category : 'tests' }
-CTAVLTreeTest >> testIsLeaf [
-
-	tree add: 50.
-	self assert: tree root isLeaf.
-	
-	tree add: 30.
-	self deny: tree root isLeaf.
-	self assert: tree root left isLeaf
-]
-
-{ #category : 'tests' }
 CTAVLTreeTest >> testLLRotation [
 
 	tree add: 3.
@@ -415,16 +389,6 @@ CTAVLTreeTest >> testNegativeNumbers [
 	self assert: tree findMax equals: 10.
 	self assert: tree asArray equals: #(-10 -5 0 5 10).
 	self assert: tree validate
-]
-
-{ #category : 'tests' }
-CTAVLTreeTest >> testParentChildRelationships [
-
-	tree addAll: #(50 30 70 20 40).
-	
-	self assert: tree root parent isNil.
-	self assert: tree root left parent equals: tree root.
-	self assert: tree root right parent equals: tree root
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Fixes #41

This PR separates the unit tests that specifically test `CTAVLNode` behavior away from the main `CTAVLTreeTest` to improve the test architecture and isolation.

**Changes:**
1. Created a new dedicated `CTAVLNodeTest` class.
2. Moved `testCopyLeafNode` to the new class.
3. Refactored and moved `testIsLeaf` and `testParentChildRelationships` to the new class as well, since these test node-level properties rather than tree-level balancing or searching.

All tests are green locally! Let me know if this looks good.