### PR TITLE
Refactor: replace isNilNode with polymorphic

### DIFF
--- a/src/Containers-AVL-Tree/CTAVLAbstractNode.class.st
+++ b/src/Containers-AVL-Tree/CTAVLAbstractNode.class.st
@@ -119,12 +119,6 @@ CTAVLAbstractNode >> isLeaf [
 	^ self subclassResponsibility 
 ]
 
-{ #category : 'testing' }
-CTAVLAbstractNode >> isNilNode [
-
-	^ false
-]
-
 { #category : 'accessing' }
 CTAVLAbstractNode >> parent [
 

--- a/src/Containers-AVL-Tree/CTAVLNode.class.st
+++ b/src/Containers-AVL-Tree/CTAVLNode.class.st
@@ -44,8 +44,11 @@ CTAVLNode >> balanceFactor [
 
 { #category : 'accessing' }
 CTAVLNode >> children [
-
-	^ { left . right }
+	| validChildren |
+	validChildren := OrderedCollection new: 2.
+	left isEmpty ifFalse: [ validChildren add: left ].
+	right isEmpty ifFalse: [ validChildren add: right ].
+	^ validChildren asArray
 ]
 
 { #category : 'accessing' }
@@ -175,10 +178,10 @@ CTAVLNode >> left: aNode [
 
 { #category : 'copying' }
 CTAVLNode >> postCopy [
-	super postCopy.
-	
-	left isNilNode ifFalse: [ left := left copy ].
-	right isNilNode ifFalse: [ right := right copy ]
+    super postCopy.
+
+    left := left copy.
+    right := right copy
 ]
 
 { #category : 'enumerating' }

--- a/src/Containers-AVL-Tree/CTAVLTree.class.st
+++ b/src/Containers-AVL-Tree/CTAVLTree.class.st
@@ -40,14 +40,13 @@ CTAVLTree >> addAll: aCollection [
 CTAVLTree >> allChildren [
 	| allNodes queue currentNode |
 	allNodes := OrderedCollection new.
-	self root isNilNode ifTrue: [ ^ allNodes ].
+	self root isEmpty ifTrue: [ ^ allNodes ]. 
 	
 	queue := OrderedCollection with: self root.
 	[ queue isNotEmpty ] whileTrue: [ 
 		currentNode := queue removeFirst.
 		allNodes add: currentNode.
-		currentNode left isNilNode ifFalse: [ queue add: currentNode left ].
-		currentNode right isNilNode ifFalse: [ queue add: currentNode right ] 
+		queue addAll: currentNode children 
 	].
 	
 	^ allNodes
@@ -231,8 +230,8 @@ CTAVLTree >> last [
 
 { #category : 'copying' }
 CTAVLTree >> postCopy [
-	super postCopy.
-	root := root copy.
+    super postCopy.
+    root := root copy.
 ]
 
 { #category : 'enumerating' }


### PR DESCRIPTION
This fixes the Null Object Pattern implementation that we talked about in #40. 

Instead of manually checking `isNilNode` everywhere, the code now relies on proper polymorphism:
- `CTAVLNode >> children`: Now filters valid children using `isEmpty` instead of checking for nil.
- `CTAVLTree >> allChildren`: Removed the manual left/right nil checks during BFS.
- `CTAVLNode >> postCopy`: Removed `isNilNode` checks since `copy` on a nil node safely returns a new nil node anyway.
- Deleted `isNilNode` from the node classes entirely since there are no senders left.

All tests are green!
<img width="976" height="721" alt="image" src="https://github.com/user-attachments/assets/c30377de-d892-4810-839e-8b7ae195bde7" />
Let me know if everything looks good